### PR TITLE
add minimum php version to composer.json to avoid warnings about synt…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         }
     ],
     "require": {
+        "php": ">=7.0",
         "league/climate": "^3.5",
         "oxid-esales/oxideshop-ce": "^6.0",
         "oxid-esales/oxideshop-unified-namespace-generator": "^2.0"


### PR DESCRIPTION
…ax in phpstorm