### PR TITLE
adds new dump mode that dumps classes that extends their parents

### DIFF
--- a/oxid-dump-autoload
+++ b/oxid-dump-autoload
@@ -1,6 +1,6 @@
 #!/usr/bin/env php
 <?php
-use AlfredBez\OxidDumpAutoload\{AliasDumper, AliasBuilder, ClassFilter, Config};
+use AlfredBez\OxidDumpAutoload\{AliasDumper, AliasBuilder, ClassFilter, Config, ExtendsDumper};
 use AlfredBez\OxidDumpAutoload\Chain\{ShopChain, MetadataChain};
 
 $dirname = dirname(__FILE__);
@@ -55,6 +55,16 @@ $climate->arguments->add([
         'description' => 'Prints a usage statement',
         'noValue'     => true,
     ],
+
+    'extends' => [
+        'longPrefix'  => 'with-extends',
+        'prefix'      => 'e',
+        'description' => 'Do not use alias statements in the generated output but generated classes
+        that extend from their parent. You may want use this to support phpstan and phpstorm',
+        'noValue'     => true,
+        'defaultValue' => false,
+        'castTo'       => 'bool',
+    ]
 ]);
 
 $climate->arguments->parse();
@@ -101,7 +111,7 @@ try {
     exit;
 }
 
-$dumper = new AliasDumper();
+$dumper = $climate->arguments->defined('extends') ? new ExtendsDumper() : new AliasDumper();
 $dump = $dumper->dump($aliasBuilder->buildAliasesFor($chain));
 if (strlen($config->get('path')) > 0) {
     file_put_contents($config->get('path'), $dump);

--- a/src/ExtendsDumper.php
+++ b/src/ExtendsDumper.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AlfredBez\OxidDumpAutoload;
+
+class ExtendsDumper
+{
+    public function dump(array $aliases): string
+    {
+        $output = '<?php ';
+        foreach ($aliases as $aliasPair) {
+
+            list($lastClassName, $moduleClass) = $aliasPair;
+            $ns = '';
+            $class = $moduleClass;
+            if (preg_match("/(.*)\\\\(.*)/",$moduleClass,$matches)) {
+                $ns = $matches[1];
+                $class = $matches[2];
+            }
+            $output .=<<<PHP
+                namespace ${ns}{
+                    class $class extends \\$lastClassName{
+                    }
+                }
+PHP;
+        }
+
+        return $output;
+    }
+}


### PR DESCRIPTION
the new mode allows to dump classes:

e.g.:
```php
namespace OxidEsales\B2BModule\ApprovalProcedure\Service{
    class BasketService_parent extends \OxidEsales\B2BModule\Basket\Service\EditService
    {
    }
}
```
because this is compatible with some applications see https://github.com/alfredbez/oxid-dump-autoload/issues/6

